### PR TITLE
Change for ruby2.6.6

### DIFF
--- a/calendav.gemspec
+++ b/calendav.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/pat/calendav"
   spec.license       = "Hippocratic-2.1"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/lib/calendav/error_handler.rb
+++ b/lib/calendav/error_handler.rb
@@ -4,8 +4,8 @@ require_relative "./errors"
 
 module Calendav
   class ErrorHandler
-    def self.call(...)
-      new(...).call
+    def self.call(response)
+      new(response).call
     end
 
     def initialize(response)

--- a/lib/calendav/multi_response.rb
+++ b/lib/calendav/multi_response.rb
@@ -8,12 +8,12 @@ module Calendav
       @document = document
     end
 
-    def each(...)
-      responses.each(...)
+    def each(*args, **kws, &block)
+      responses.each(*args, **kws, &block)
     end
 
-    def xpath(...)
-      document.xpath(...)
+    def xpath(*args, **kws, &block)
+      document.xpath(*args, **kws, &block)
     end
 
     private

--- a/lib/calendav/parsers/calendar_xml.rb
+++ b/lib/calendav/parsers/calendar_xml.rb
@@ -13,8 +13,8 @@ module Calendav
         sync_token: ".//dav:sync-token"
       }.freeze
 
-      def self.call(...)
-        new(...).call
+      def self.call(element)
+        new(element).call
       end
 
       def initialize(element)

--- a/lib/calendav/parsers/event_xml.rb
+++ b/lib/calendav/parsers/event_xml.rb
@@ -3,8 +3,8 @@
 module Calendav
   module Parsers
     class EventXML
-      def self.call(...)
-        new(...).call
+      def self.call(element)
+        new(element).call
       end
 
       def initialize(element)

--- a/lib/calendav/parsers/response_xml.rb
+++ b/lib/calendav/parsers/response_xml.rb
@@ -7,8 +7,8 @@ require_relative "../namespaces"
 module Calendav
   module Parsers
     class ResponseXML
-      def self.call(...)
-        new(...).call
+      def self.call(raw, namespaces = NAMESPACES)
+        new(raw, namespaces = NAMESPACES).call
       end
 
       def initialize(raw, namespaces = NAMESPACES)

--- a/lib/calendav/parsers/sync_xml.rb
+++ b/lib/calendav/parsers/sync_xml.rb
@@ -7,8 +7,8 @@ require_relative "../sync_collection"
 module Calendav
   module Parsers
     class SyncXML
-      def self.call(...)
-        new(...).call
+      def self.call(calendar_url, multi_response)
+        new(calendar_url, multi_response).call
       end
 
       def initialize(calendar_url, multi_response)

--- a/lib/calendav/requests/calendar_home_set.rb
+++ b/lib/calendav/requests/calendar_home_set.rb
@@ -7,8 +7,8 @@ require_relative "../namespaces"
 module Calendav
   module Requests
     class CalendarHomeSet
-      def self.call(...)
-        new(...).call
+      def self.call
+        new.call
       end
 
       def call

--- a/lib/calendav/requests/current_user_principal.rb
+++ b/lib/calendav/requests/current_user_principal.rb
@@ -7,8 +7,8 @@ require_relative "../namespaces"
 module Calendav
   module Requests
     class CurrentUserPrincipal
-      def self.call(...)
-        new(...).call
+      def self.call
+        new.call
       end
 
       def call

--- a/lib/calendav/requests/list_calendars.rb
+++ b/lib/calendav/requests/list_calendars.rb
@@ -22,8 +22,8 @@ module Calendav
         }
       ].freeze
 
-      def self.call(...)
-        new(...).call
+      def self.call(attributes)
+        new(attributes).call
       end
 
       def initialize(attributes)

--- a/lib/calendav/requests/list_events.rb
+++ b/lib/calendav/requests/list_events.rb
@@ -7,8 +7,8 @@ require_relative "../namespaces"
 module Calendav
   module Requests
     class ListEvents
-      def self.call(...)
-        new(...).call
+      def self.call(from:, to:)
+        new(from: from, to: to).call
       end
 
       def initialize(from:, to:)

--- a/lib/calendav/requests/make_calendar.rb
+++ b/lib/calendav/requests/make_calendar.rb
@@ -7,8 +7,8 @@ require_relative "../namespaces"
 module Calendav
   module Requests
     class MakeCalendar
-      def self.call(...)
-        new(...).call
+      def self.call(attributes)
+        new(attributes).call
       end
 
       def initialize(attributes)

--- a/lib/calendav/requests/sync_collection.rb
+++ b/lib/calendav/requests/sync_collection.rb
@@ -7,8 +7,8 @@ require_relative "../namespaces"
 module Calendav
   module Requests
     class SyncCollection
-      def self.call(...)
-        new(...).call
+      def self.call(token)
+        new(token).call
       end
 
       def initialize(token)

--- a/lib/calendav/requests/update_calendar.rb
+++ b/lib/calendav/requests/update_calendar.rb
@@ -7,8 +7,8 @@ require_relative "../namespaces"
 module Calendav
   module Requests
     class UpdateCalendar
-      def self.call(...)
-        new(...).call
+      def self.call(attributes)
+        new(attributes).call
       end
 
       def initialize(attributes)


### PR DESCRIPTION
3 dots as a method argument is not supported by ruby 2.6.6
1- all occurrences are replaced with proper arguments.
2- required ruby version is changed to >= 2.6.6

**To Test** 
add `gem 'calendav', require: false, path: '../calendav'` to gemfile
ensure you run ruby 2.6.6
open a ruby console and `require 'calendav'`. it should not raise any error
you may also want to test it by connecting to Caldav Server (if you have one running in ur machine)

````

credentials = Calendav::Credentials::Standard.new(host: " http://localhost:8080/remote.php/dav",username: username, password: password, authentication: :basic_auth)

client =  Calendav.client(credentials)
calendras = client.calendars.list
events = client.events.list(calendars.first.url)
````
