### PR TITLE
Support OAuth authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ credentials = Calendav::Credentials::Standard.new(
   host: "https://www.example.com/caldav",
   username: "example",
   password: "secret",
-  authentication: :basic_auth # or :bearer_token
+  authentication: :basic_auth # :bearer_token and :oauth also supported
 )
 ```
 

--- a/lib/calendav/endpoint.rb
+++ b/lib/calendav/endpoint.rb
@@ -85,6 +85,8 @@ module Calendav
         HTTP.basic_auth(user: credentials.username, pass: credentials.password)
       when :bearer_token
         HTTP.auth("Bearer #{credentials.password}")
+      when :oauth
+        HTTP.auth("OAuth #{credentials.password}")
       else
         raise "Unexpected authentication approach: " \
               "#{credentials.authentication}"


### PR DESCRIPTION
Recently I needed to work with my Yandex Calendar via CalDav.
[The documentation says](https://yandex.ru/support/yandex-360/business/admin/ru/security-service-applications) that working with CalDav is done using OAuth tokens.
This PR adds the ability to use a pre-generated OAuth token for authorization.