### PR TITLE
Add transp event attribute

### DIFF
--- a/lib/calendav/event.rb
+++ b/lib/calendav/event.rb
@@ -45,6 +45,10 @@ module Calendav
       inner_event.dtend
     end
 
+    def transp
+      inner_event.transp
+    end
+
     def unloaded?
       calendar_data.nil?
     end


### PR DESCRIPTION
Currently, it’s necessary to this `event.send(:inner_event).transp` if you want to get `transp` VEVENT attribute.

I suggest exposing it.

Cf : https://www.ietf.org/rfc/rfc2445.txt (4.8.2.7 Time Transparency)